### PR TITLE
Remove encoding polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,6 @@ module.exports = {
         }),
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
-        }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
     mode: 'development',


### PR DESCRIPTION
Not needed in Edge 79+ and made the webpack huge.
