### PR TITLE
Use separate compile, package scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install tools
       run: cargo install wasm-pack
     - name: Pack
-      run: npm run build
+      run: npm run package
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "scripts": {
-        "prebuild": "wasm-pack build --target web --release",
-        "build": "webpack --mode=production",
-        "prestart": "wasm-pack build --target web --dev",
+        "compile": "webpack",
+        "package": "webpack --mode=production --no-devtool",
         "start": "webpack-dev-server"
     },
     "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
         })
     ],
     mode: 'development',
+    devtool: 'nosources-source-map',
     experiments: {
         asyncWebAssembly: true
     }


### PR DESCRIPTION
Unifies on "compile" like heaths/vscode-msi, providing basic debugging,
with a separate "package" script to better optimize for deployment.
